### PR TITLE
macOS app fix for help.htm path

### DIFF
--- a/LaSolv_mac.spec
+++ b/LaSolv_mac.spec
@@ -1,44 +1,51 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 
-block_cipher = None
+a = Analysis(
+    ['src/gui_wx.py'],
+    pathex=['src'],
+    binaries=[],
+    datas=[('src/help.htm', '.')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
 
-
-a = Analysis(['LaSolv/gui_wx.py'],
-             pathex=[],
-             binaries=[],
-             datas=[],
-             hiddenimports=[],
-             hookspath=[],
-             hooksconfig={},
-             runtime_hooks=[],
-             excludes=[],
-             win_no_prefer_redirects=False,
-             win_private_assemblies=False,
-             cipher=block_cipher,
-             noarchive=False)
-pyz = PYZ(a.pure, a.zipped_data,
-             cipher=block_cipher)
-
-exe = EXE(pyz,
-          a.scripts,
-          a.binaries,
-          a.zipfiles,
-          a.datas,  
-          [],
-          name='LaSolv',
-          debug=False,
-          bootloader_ignore_signals=False,
-          strip=True,
-          upx=True,
-          upx_exclude=[],
-          runtime_tmpdir=None,
-          console=False,
-          disable_windowed_traceback=False,
-          target_arch=None,
-          codesign_identity=None,
-          entitlements_file=None , icon='LaSolv/LaSolv_icon.icns')
-app = BUNDLE(exe,
-             name='LaSolv.app',
-             icon='LaSolv/LaSolv_icon.icns',
-             bundle_identifier=None)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='LaSolv',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch='arm64',
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['src/LaSolv_icon.icns'],
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='LaSolv',
+)
+app = BUNDLE(
+    coll,
+    name='LaSolv.app',
+    icon='src/LaSolv_icon.icns',
+    bundle_identifier=None,
+)

--- a/make_mac_spec.txt
+++ b/make_mac_spec.txt
@@ -1,0 +1,5 @@
+#!/bin/zsh
+mv LaSolv.spec  LaSolv.spec.tmp
+pyi-makespec --windowed --onedir  --name 'LaSolv' --icon 'src/LaSolv_icon.icns' --paths 'src' --add-data 'src/help.htm:.' --target-arch arm64 --windowed src/gui_wx.py
+mv LaSolv.spec LaSolv_mac.spec
+mv LaSolv.spec.tmp Lasolv.spec

--- a/make_mac_spec.txt
+++ b/make_mac_spec.txt
@@ -2,4 +2,4 @@
 mv LaSolv.spec  LaSolv.spec.tmp
 pyi-makespec --windowed --onedir  --name 'LaSolv' --icon 'src/LaSolv_icon.icns' --paths 'src' --add-data 'src/help.htm:.' --target-arch arm64 --windowed src/gui_wx.py
 mv LaSolv.spec LaSolv_mac.spec
-mv LaSolv.spec.tmp Lasolv.spec
+mv LaSolv.spec.tmp LaSolv.spec

--- a/src/gui_wx.py
+++ b/src/gui_wx.py
@@ -403,7 +403,7 @@ class eqs(wx.Frame):
         dlg.ShowModal()
         dlg.Destroy()
 
-   def resource_path(self,relative_path):
+    def resource_path(self,relative_path):
         """ Get absolute path to resource, works for dev and for PyInstaller """
         base_path = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
         return os.path.join(base_path, relative_path)
@@ -419,7 +419,7 @@ class eqs(wx.Frame):
         if os.path.exists(pth):
             thePath = pth
 
-       if thePath is not None:
+        if thePath is not None:
             provider = wx.SimpleHelpProvider()
             wx.HelpProvider.Set(provider)
 

--- a/src/gui_wx.py
+++ b/src/gui_wx.py
@@ -403,15 +403,23 @@ class eqs(wx.Frame):
         dlg.ShowModal()
         dlg.Destroy()
 
+   def resource_path(self,relative_path):
+        """ Get absolute path to resource, works for dev and for PyInstaller """
+        base_path = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
+        return os.path.join(base_path, relative_path)
+
     def onHelp(self, event):
         thePath = None
-        pths = ["../help.htm", "help.htm", "../../help.htm"]
-        for pth in pths:
-            if os.path.exists(pth):
-                thePath = pth
-                break
+#        pths = ["../help.htm", "./help.htm", "../../help.htm"]        
+#        for pth in pths:        
+#            if os.path.exists(pth):
+#                thePath = pth
+#                break
+        pth = self.resource_path('./help.htm')        
+        if os.path.exists(pth):
+            thePath = pth
 
-        if thePath is not None:
+       if thePath is not None:
             provider = wx.SimpleHelpProvider()
             wx.HelpProvider.Set(provider)
 


### PR DESCRIPTION
Changes  to search path for `help.htm` that should work in both dev and pyInstaller built app bundles.   Since you are not on Apple Silicon, just remove the `architecture` settings or change to x86_64.
[https://pyinstaller.org/en/stable/usage.html#cmdoption-target-architecture](url)

Steps to use:
```
(1)  >  make_mac_spec.txt
(2)  >  pyinstaller --clean LaSolv_mac.spec
(3)     move  dist/LaSolv.app   /Applications/LaSolv.app
```